### PR TITLE
Changes to make Parse work on Unity 5.4/IL2CPP

### DIFF
--- a/AssemblyLister/AssemblyLister.Unity/AssemblyLister.cs
+++ b/AssemblyLister/AssemblyLister.Unity/AssemblyLister.cs
@@ -33,8 +33,18 @@ namespace AssemblyLister {
         if (seen.Contains(reference.FullName))
           continue;
 
-        Assembly referencedAsm = Assembly.Load(reference);
-        assemblies.AddRange(referencedAsm.DeepWalkReferences(seen));
+        try {
+          Assembly referencedAsm = Assembly.Load(reference);
+          assemblies.AddRange(referencedAsm.DeepWalkReferences(seen));
+        }
+        catch (System.IO.FileNotFoundException) {
+          if (reference.Name == "UnityEditor.iOS.Extensions.Xcode") {
+            // It's okay. On Windows, this won't exist.
+          }
+          else {
+            throw; // this is an actual problem
+          }
+        }
       }
 
       return assemblies;

--- a/Parse.StarterProjects/CSharp/ParseUnityStarterProject/Assets/link.xml
+++ b/Parse.StarterProjects/CSharp/ParseUnityStarterProject/Assets/link.xml
@@ -1,6 +1,5 @@
 ﻿<linker>
-  <assembly fullname="Parse.Unity">
-    <namespace fullname="Parse" preserve="all"/>
-    <namespace fullname="Parse.Internal" preserve="all"/>
+  <assembly fullname="Parse.Common">
+    <namespace fullname="Parse.Common.Internal" preserve="all"/>
   </assembly>
 </linker>

--- a/ParseCommon/Internal/Storage/IStorageController.cs
+++ b/ParseCommon/Internal/Storage/IStorageController.cs
@@ -19,6 +19,13 @@ namespace Parse.Common.Internal {
     /// <param name="contents"></param>
     /// <returns></returns>
     Task<IStorageDictionary<string, object>> SaveAsync(IDictionary<string, object> contents);
+
+    /// <summary>
+    /// Do any setup necessary before the object is used--particularly
+    /// code which must run in the Unity thread.
+    /// </summary>
+    /// <returns></returns>
+    void Initialize();
   }
 
   /// <summary>

--- a/ParseCommon/Internal/Storage/Portable/StorageController.cs
+++ b/ParseCommon/Internal/Storage/Portable/StorageController.cs
@@ -122,6 +122,10 @@ namespace Parse.Common.Internal {
       this.fileTask = Task.FromResult(file);
     }
 
+    public void Initialize() {
+      // no init needed
+    }
+
     public Task<IStorageDictionary<string, object>> LoadAsync() {
       return taskQueue.Enqueue(toAwait => {
         return toAwait.ContinueWith(_ => {

--- a/ParseCommon/Internal/Storage/Unity/StorageController.cs
+++ b/ParseCommon/Internal/Storage/Unity/StorageController.cs
@@ -16,6 +16,7 @@ namespace Parse.Common.Internal {
     private TaskQueue taskQueue = new TaskQueue();
     private string settingsPath;
     private StorageDictionary storageDictionary;
+    private static bool isWebPlayer;
 
     private class StorageDictionary : IStorageDictionary<string, object> {
       private object mutex;
@@ -35,7 +36,7 @@ namespace Parse.Common.Internal {
           jsonEncoded = Json.Encode(dictionary);
         }
 
-        if (Application.isWebPlayer) {
+        if (StorageController.isWebPlayer) {
           PlayerPrefs.SetString(ParseStorageFileName, jsonEncoded);
           PlayerPrefs.Save();
         } else if (Application.platform == RuntimePlatform.tvOS) {
@@ -55,7 +56,7 @@ namespace Parse.Common.Internal {
         string jsonString = null;
 
         try {
-          if (Application.isWebPlayer) {
+          if (StorageController.isWebPlayer) {
             jsonString = PlayerPrefs.GetString(ParseStorageFileName, null);
           } else if (Application.platform == RuntimePlatform.tvOS) {
             Debug.Log("Running on TvOS, prefs cannot be loaded.");
@@ -146,6 +147,10 @@ namespace Parse.Common.Internal {
 
     public StorageController() {
       settingsPath = Path.Combine(Application.persistentDataPath, ParseStorageFileName);
+    }
+
+    public void Initialize() {
+      isWebPlayer = Application.isWebPlayer;
     }
 
     public StorageController(String settingsPath) {

--- a/ParseCore/Public/ParseClient.cs
+++ b/ParseCore/Public/ParseClient.cs
@@ -150,6 +150,8 @@ namespace Parse {
         ParseObject.RegisterSubclass<ParseRole>();
         ParseObject.RegisterSubclass<ParseSession>();
 
+        Parse.Core.Internal.ParseCorePlugins.Instance.StorageController.Initialize();
+
         ParseModuleController.Instance.ParseDidInitialize();
       }
     }

--- a/ParseCore/Public/ParseUser.cs
+++ b/ParseCore/Public/ParseUser.cs
@@ -275,7 +275,6 @@ namespace Parse {
     /// Typically, you should use <see cref="LogOutAsync()"/>, unless you are managing your own threading.
     /// </remarks>
     public static void LogOut() {
-      // TODO (hallucinogen): this will without a doubt fail in Unity. But what else can we do?
       LogOutAsync().Wait();
     }
 
@@ -338,7 +337,6 @@ namespace Parse {
     public static ParseUser CurrentUser {
       get {
         var userTask = GetCurrentUserAsync();
-        // TODO (hallucinogen): this will without a doubt fail in Unity. How should we fix it?
         userTask.Wait();
         return userTask.Result;
       }

--- a/ParsePush/Public/ParseInstallation.cs
+++ b/ParsePush/Public/ParseInstallation.cs
@@ -52,7 +52,6 @@ namespace Parse {
     public static ParseInstallation CurrentInstallation {
       get {
         var task = CurrentInstallationController.GetAsync(CancellationToken.None);
-        // TODO (hallucinogen): this will absolutely break on Unity, but how should we resolve this?
         task.Wait();
         return task.Result;
       }

--- a/Unity.Tasks/Public/Task.cs
+++ b/Unity.Tasks/Public/Task.cs
@@ -87,13 +87,16 @@ namespace System.Threading.Tasks {
     /// Blocks until the task is complete.
     /// </summary>
     public void Wait() {
-      lock (mutex) {
-        if (!IsCompleted) {
-          Monitor.Wait(mutex);
+      while (true) {
+        lock (mutex) {
+          if (IsCompleted) {
+            return;
+          }
+          if (IsFaulted) {
+            throw Exception;
+          }
         }
-        if (IsFaulted) {
-          throw Exception;
-        }
+        Thread.Sleep(0);
       }
     }
 


### PR DESCRIPTION
@hallucinogen I noticed your comments about the functions that call `Wait()` not working in Unity. (`ParseUser.CurrentUser` was throwing an exception for me.) I don't know what it is about Unity's threading model that causes the problem, but getting rid of `Monitor.Wait()` seems to solve it. Also, the old code looked funny: it got the lock, waited once, then assumed the task was done. Is it guaranteed the next thread in the queue will complete the task?

(The other commit: after Parse was modularized, the assembly/namespace names in task.xml should be updated or there are link errors.)
