### PR TITLE
Type forwarding DLL for the Parse Task implementation and Unity plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+
+# Include all files in Unity project templates.
+!**/UnityProjectTemplate/**

--- a/Unity.Tasks.TypeForwards/Properties/AssemblyInfo.cs
+++ b/Unity.Tasks.TypeForwards/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2015-present, Parse, LLC.  All rights reserved.  This source code is licensed under the BSD-style license found in the LICENSE file in the root directory of this source tree.  An additional grant of patent rights can be found in the PATENTS file in the same directory.
+
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Parse")]
+[assembly: AssemblyDescription("Makes accessing services from Parse native and straightforward.")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Parse")]
+[assembly: AssemblyCopyright("Copyright © Parse 2012")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(true)]

--- a/Unity.Tasks.TypeForwards/Public/TaskTypeForwards.cs
+++ b/Unity.Tasks.TypeForwards/Public/TaskTypeForwards.cs
@@ -1,0 +1,14 @@
+using System.Runtime.CompilerServices;
+
+[assembly: TypeForwardedToAttribute(typeof(System.AggregateException))]
+[assembly: TypeForwardedToAttribute(typeof(System.Threading.CancellationToken))]
+[assembly: TypeForwardedToAttribute(typeof(System.Threading.CancellationTokenRegistration))]
+[assembly: TypeForwardedToAttribute(typeof(System.Threading.CancellationTokenSource))]
+[assembly: TypeForwardedToAttribute(typeof(System.Threading.Tasks.Task))]
+[assembly: TypeForwardedToAttribute(typeof(System.Threading.Tasks.Task<>))]
+[assembly: TypeForwardedToAttribute(typeof(System.Threading.Tasks.TaskCompletionSource<>))]
+[assembly: TypeForwardedToAttribute(typeof(System.Threading.Tasks.TaskContinuationOptions))]
+[assembly: TypeForwardedToAttribute(typeof(System.Threading.Tasks.TaskCreationOptions))]
+[assembly: TypeForwardedToAttribute(typeof(System.Threading.Tasks.TaskExtensions))]
+[assembly: TypeForwardedToAttribute(typeof(System.Threading.Tasks.TaskFactory))]
+[assembly: TypeForwardedToAttribute(typeof(System.Threading.Tasks.TaskScheduler))]

--- a/Unity.Tasks.TypeForwards/Unity.Tasks.TypeForwards.csproj
+++ b/Unity.Tasks.TypeForwards/Unity.Tasks.TypeForwards.csproj
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F4A424D3-1BBF-4F29-BE8E-D1336505987E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Unity.Tasks</RootNamespace>
+    <AssemblyName>Unity.Tasks</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\Unity\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;UNITY</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\Unity\</OutputPath>
+    <DefineConstants>TRACE;UNITY</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
+    <DocumentationFile>bin\Release\Unity\Unity.Tasks.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Assembly info, etc. -->
+    <Compile Include="Properties\*.cs" />
+    <Compile Include="Public\**\*.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Unity.Tasks.UnityPlugin/Properties/AssemblyInfo.cs
+++ b/Unity.Tasks.UnityPlugin/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2015-present, Parse, LLC.  All rights reserved.  This source code is licensed under the BSD-style license found in the LICENSE file in the root directory of this source tree.  An additional grant of patent rights can be found in the PATENTS file in the same directory.
+
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Parse")]
+[assembly: AssemblyDescription("Makes accessing services from Parse native and straightforward.")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Parse")]
+[assembly: AssemblyCopyright("Copyright © Parse 2012")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(true)]

--- a/Unity.Tasks.UnityPlugin/Unity.Tasks.UnityPlugin.csproj
+++ b/Unity.Tasks.UnityPlugin/Unity.Tasks.UnityPlugin.csproj
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2B36560F-64B5-4CEE-9F85-ED8A4FA64A1B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Unity.Tasks</RootNamespace>
+    <AssemblyName>Unity.Tasks.UnityPlugin</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\Unity\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;UNITY</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\Unity\</OutputPath>
+    <DefineConstants>TRACE;UNITY</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
+    <DocumentationFile>bin\Release\Unity\Unity.Tasks.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\UnityEngine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Assembly info, etc. -->
+    <Compile Include="Properties\*.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <ItemGroup>
+    <ProjectReference Include="..\Unity.Tasks\Unity.Tasks.csproj">
+      <Project>{CE75C800-A97F-4464-9A8B-3F65258456BF}</Project>
+      <Name>Unity.Tasks</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Unity.Tasks.TypeForwards\Unity.Tasks.TypeForwards.csproj">
+      <Project>{F4A424D3-1BBF-4F29-BE8E-D1336505987E}</Project>
+      <Name>Unity.Tasks.TypeForwards</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <UnityProjectTemplatePath>UnityProjectTemplate</UnityProjectTemplatePath>
+    <UnityProjectIntermediatePath>$(IntermediateOutputPath)\UnityProject</UnityProjectIntermediatePath>
+    <UnityExecutablePath Condition="'$(OS)' == 'Windows'">$(ProgramFiles)\Unity\Editor\Unity.exe</UnityExecutablePath>
+    <UnityExecutablePath Condition="'$(OS)' == 'Unix'">/Applications/Unity/Unity.app/Contents/MacOS/Unity</UnityExecutablePath>
+    <BuildUnityPlugin Condition="'$(BuildUnityPlugin)' == ''">1</BuildUnityPlugin>
+  </PropertyGroup>
+  <ItemGroup>
+    <UnityProjectTemplateFiles Include="UnityProjectTemplate\**\*.meta" />
+  </ItemGroup>
+  <Target Name="CreateUnityProject">
+    <!-- Generate the Unity project. -->
+    <Copy SourceFiles="@(UnityProjectTemplateFiles)"
+          DestinationFolder="$(UnityProjectIntermediatePath)\%(RecursiveDir)" />
+    <Copy SourceFiles="..\Unity.Compat\$(OutputPath)\Unity.Compat.dll;
+                       ..\Unity.Tasks\$(OutputPath)\Unity.Tasks.dll;
+                       ..\Unity.Tasks.TypeForwards\$(OutputPath)\Unity.Tasks.dll;"
+          DestinationFiles="
+              $(UnityProjectIntermediatePath)\Assets\Parse\Plugins\Unity.Compat.dll;
+              $(UnityProjectIntermediatePath)\Assets\Parse\Plugins\Unity.Tasks.dll;
+              $(UnityProjectIntermediatePath)\Assets\Parse\Plugins\dotNet45\Unity.Tasks.dll;" />
+  </Target>
+  <Target Name="BuildUnityPlugin"
+          DependsOnTargets="CreateUnityProject"
+          Condition="'$(BuildUnityPlugin)' == '1'">
+    <!-- Convert paths to absolute paths (required to run Unity).
+         ConvertToAbsolutePath isn't available in xbuild so use CreateItem to expand the path. -->
+    <CreateItem Include="$(UnityProjectIntermediatePath)">
+      <Output TaskParameter="Include" ItemName="_UnityProjectIntermediatePath" />
+    </CreateItem>
+    <CreateItem Include="$(IntermediateOutputPath)">
+      <Output TaskParameter="Include" ItemName="_IntermediateOutputPath" />
+    </CreateItem>
+    <CreateItem Include="$(OutputPath)">
+      <Output TaskParameter="Include" ItemName="_OutputPath" />
+    </CreateItem>
+    <!-- Run Unity to generate the plugin package. -->
+    <ItemGroup>
+      <UnityArgs Include="-batchmode" />
+      <UnityArgs Include="-projectPath &quot;%(_UnityProjectIntermediatePath.FullPath)&quot;" />
+      <UnityArgs Include="-logFile &quot;%(_IntermediateOutputPath.FullPath)/UnityProject.log&quot;" />
+      <UnityArgs Include="-exportPackage Assets/Parse &quot;%(_OutputPath.FullPath)/ParseTasks.unitypackage&quot;" />
+      <UnityArgs Include="-quit" />
+    </ItemGroup>
+    <Exec Command="&quot;$(UnityExecutablePath)&quot; @(UnityArgs,' ')" Outputs="$(OutputPath)/ParseTasks.unitypackage" />
+  </Target>
+  <Target Name="AfterBuild" DependsOnTargets="CreateUnityProject;BuildUnityPlugin"/>
+</Project>

--- a/Unity.Tasks.UnityPlugin/UnityProjectTemplate/Assets/Parse.meta
+++ b/Unity.Tasks.UnityPlugin/UnityProjectTemplate/Assets/Parse.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 1199e2794125469e8a23856b0799dd41
+folderAsset: yes
+timeCreated: 1500423342
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity.Tasks.UnityPlugin/UnityProjectTemplate/Assets/Parse/Plugins.meta
+++ b/Unity.Tasks.UnityPlugin/UnityProjectTemplate/Assets/Parse/Plugins.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 29090946a760432f873fd7e78b773dd7
+folderAsset: yes
+timeCreated: 1500423342
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity.Tasks.UnityPlugin/UnityProjectTemplate/Assets/Parse/Plugins/Unity.Compat.dll.meta
+++ b/Unity.Tasks.UnityPlugin/UnityProjectTemplate/Assets/Parse/Plugins/Unity.Compat.dll.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: 015ef18e20f24535830f59eda9e70830
+labels:
+- gvh
+- gvh_dotnet-3.5
+timeCreated: 1500423342
+licenseType: Pro
+PluginImporter:
+  serializedVersion: 1
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  platformData:
+    Any:
+      enabled: 1
+      settings: {}
+    Editor:
+      enabled: 1
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity.Tasks.UnityPlugin/UnityProjectTemplate/Assets/Parse/Plugins/Unity.Tasks.dll.meta
+++ b/Unity.Tasks.UnityPlugin/UnityProjectTemplate/Assets/Parse/Plugins/Unity.Tasks.dll.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: 93324a471a6d44bb8297d17d8b191e52
+labels:
+- gvh
+timeCreated: 1500423342
+licenseType: Pro
+PluginImporter:
+  serializedVersion: 1
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  platformData:
+    Any:
+      enabled: 1
+      settings: {}
+    Editor:
+      enabled: 1
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity.Tasks.UnityPlugin/UnityProjectTemplate/Assets/Parse/Plugins/dotNet45.meta
+++ b/Unity.Tasks.UnityPlugin/UnityProjectTemplate/Assets/Parse/Plugins/dotNet45.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 9b73100528004036bb54eac84b0d0992
+folderAsset: yes
+timeCreated: 1500423342
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity.Tasks.UnityPlugin/UnityProjectTemplate/Assets/Parse/Plugins/dotNet45/Unity.Tasks.dll.meta
+++ b/Unity.Tasks.UnityPlugin/UnityProjectTemplate/Assets/Parse/Plugins/dotNet45/Unity.Tasks.dll.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: bd18eee30834e4f71bded96fd14033a9
+labels:
+- gvh
+- gvh_dotnet-4.5
+timeCreated: 1500423342
+licenseType: Pro
+PluginImporter:
+  serializedVersion: 1
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  platformData:
+    Any:
+      enabled: 0
+      settings: {}
+    Editor:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This patch introduces:
* Type forwarding DLL for Parse implementation of System.Threading.Tasks.
* Project which builds a Unity plugin package that can be used to redistribute
  Parse's implementation of System.Threading.Tasks.

Unity 2017 adds experimental support for .NET 4.5 (upgrading from a partially
compatible version of .NET 3.5).  With .NET 4.5, the Parse Task implementation
is no longer required as System.Threading.Task is present in the .NET
framework.  For users distributing assemblies built against the Unity.Compat.dll
and Unity.Tasks.dll components, this results in Unity failing to compile
assemblies when .NET 4.5 is selected due to duplicate implementations of
System.Threading.Tasks.

So for the .NET 4.5 configuration in Unity, the Unity.Tasks.dll assembly (built
by Unity.Tasks.TypeForwards) has been introduced which simply type forwards to
the system implementation of System.Threading.Tasks.

To standardize the location of Unity.Tasks.dll and Unity.Compat.dll for plugin
developers reusing these components, a project has been introduced
(Unity.Tasks.UnityPlugin) which builds a ParseTasks.unitypackage containing
both the .NET 3.5 Parse implementation of System.Threading.Tasks and the
.NET 4.5 type forwarding DLL.

Finally, asset labels are used to mark .NET compatibilty of assemblies in the
ParseTasks.unitypackage and asset metadata is used to disable the .NET 4.5
type forwarding DLL by default allowing successful compilation when .NET 3.5 is
selected in Unity.  The asset labels utilized to mark .NET compatibility of
assemblies can be used by Unity editor plugins (e.g Google.VersionHandler.dll
distributed as part of https://github.com/googlesamples/unity-jar-resolver) to
enable / disable assemblies based upon the .NET framework version selected
smoothing out the end user experience.