### PR TITLE
Disable .NET 3.x Unity.Tasks.dll in .NET 4.x.

### DIFF
--- a/Unity.Tasks.UnityPlugin/UnityProjectTemplate/Assets/Parse/Plugins/Unity.Tasks.dll.meta
+++ b/Unity.Tasks.UnityPlugin/UnityProjectTemplate/Assets/Parse/Plugins/Unity.Tasks.dll.meta
@@ -2,6 +2,7 @@ fileFormatVersion: 2
 guid: 93324a471a6d44bb8297d17d8b191e52
 labels:
 - gvh
+- gvh_dotnet-3.5
 timeCreated: 1500423342
 licenseType: Pro
 PluginImporter:


### PR DESCRIPTION
This labels Parse/Plugins/Unity.Tasks.dll (the real implementation)
with the gvh_dotnet-3.5 label so that the DLL is only enabled by
Version Handler (https://github.com/googlesamples/unity-jar-resolver)
if .NET 4.x is enabled.