### PR TITLE
Fixed CurrentInstallation caching - added missing exclamation point

### DIFF
--- a/Parse/Public/ParseInstallation.cs
+++ b/Parse/Public/ParseInstallation.cs
@@ -284,7 +284,7 @@ namespace Parse
                 return base.SaveAsync(toAwait, cancellationToken);
             }).Unwrap().OnSuccess(_ =>
             {
-                if (CurrentInstallationController.IsCurrent(this))
+                if (!CurrentInstallationController.IsCurrent(this))
                 {
                     return Task.FromResult(0);
                 }


### PR DESCRIPTION
The currentInstallation object was never cached between app launches, because the exclamation mark was missing. When you look at the similar code in ParseUser, the exclamation mark is there, confirming this is a typo.