### PR TITLE
Use invariant device locale for number format conversion

### DIFF
--- a/Parse.Test/ConversionTests.cs
+++ b/Parse.Test/ConversionTests.cs
@@ -18,5 +18,22 @@ namespace Parse.Test
 
         [TestMethod]
         public void TestToWithConstructedNullableNonPrimitive() => Assert.ThrowsException<InvalidCastException>(() => Conversion.To<DummyValueTypeA?>(new DummyValueTypeB { }));
+
+
+
+        [TestMethod]
+        public void TestConvertToFloatUsingNonInvariantNumberFormat()
+        {
+            try
+            {
+                float inputValue = 1234.56f;
+                string jsonEncoded = Common.Internal.Json.Encode(inputValue);
+                float convertedValue = (float) Conversion.ConvertTo<float>(jsonEncoded);
+                Assert.IsTrue(inputValue == convertedValue);
+            }
+            catch (Exception ex)
+            { throw ex; }
+        }
+
     }
 }

--- a/Parse/Internal/ParseCorePlugins.cs
+++ b/Parse/Internal/ParseCorePlugins.cs
@@ -7,6 +7,10 @@ using System.Text;
 using Parse.Common.Internal;
 using Parse.Core.Internal;
 
+#if DEBUG
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Parse.Test")]
+#endif
+
 namespace Parse.Core.Internal
 {
     public class ParseCorePlugins : IParseCorePlugins

--- a/Parse/Public/ParseClient.cs
+++ b/Parse/Public/ParseClient.cs
@@ -213,19 +213,19 @@ namespace Parse
         /// <summary>
         /// Authenticates this client as belonging to your application. This must be
         /// called before your application can use the Parse library. The recommended
-        /// way is to put a call to <c>ParseFramework.Initialize</c> in your
+        /// way is to put a call to <c>ParseClient.Initialize</c> in your
         /// Application startup.
         /// </summary>
         /// <param name="identifier">The Application ID provided in the Parse dashboard.
         /// </param>
-        /// <param name="key">The .NET API Key provided in the Parse dashboard.
+        /// <param name="serverURI">The server URI provided in the Parse dashboard.
         /// </param>
-        public static void Initialize(string identifier, string key) => Initialize(new Configuration { ApplicationID = identifier, Key = key });
+        public static void Initialize(string identifier, string serverURI) => Initialize(new Configuration { ApplicationID = identifier, ServerURI = serverURI });
 
         /// <summary>
         /// Authenticates this client as belonging to your application. This must be
         /// called before your application can use the Parse library. The recommended
-        /// way is to put a call to <c>ParseFramework.Initialize</c> in your
+        /// way is to put a call to <c>ParseClient.Initialize</c> in your
         /// Application startup.
         /// </summary>
         /// <param name="configuration">The configuration to initialize Parse with.

--- a/Parse/Public/ParseObject.cs
+++ b/Parse/Public/ParseObject.cs
@@ -218,7 +218,18 @@ namespace Parse
         /// <typeparam name="T">The ParseObject subclass type to register.</typeparam>
         public static void RegisterSubclass<T>() where T : ParseObject, new() => SubclassingController.RegisterSubclass(typeof(T));
 
+        /// <summary>
+        /// Registers a custom subclass type with the Parse SDK, enabling strong-typing of those ParseObjects whenever
+        /// they appear. Subclasses must specify the ParseClassName attribute, have a default constructor, and properties
+        /// backed by ParseObject fields should have ParseFieldName attributes supplied.
+        /// </summary>
+        /// <param name="type">The ParseObject subclass type to register.</param>
+        public static void RegisterSubclass(Type type) { if (typeof(ParseObject).IsAssignableFrom(type)) SubclassingController.RegisterSubclass(type); }
+
         internal static void UnregisterSubclass<T>() where T : ParseObject, new() => SubclassingController.UnregisterSubclass(typeof(T));
+        internal static void UnregisterSubclass(Type type) { if (typeof(ParseObject).IsAssignableFrom(type)) SubclassingController.UnregisterSubclass(type); }
+
+
 
         /// <summary>
         /// Clears any changes to this object made since the last call to <see cref="SaveAsync()"/>.

--- a/Parse/Public/Utilities/Conversion.cs
+++ b/Parse/Public/Utilities/Conversion.cs
@@ -54,7 +54,7 @@ namespace Parse.Utilities
 
             if (ReflectionHelpers.IsPrimitive(typeof(T)))
             {
-                return (T) Convert.ChangeType(value, typeof(T));
+                return (T) Convert.ChangeType(value, typeof(T), System.Globalization.CultureInfo.InvariantCulture);
             }
 
             if (ReflectionHelpers.IsConstructedGenericType(typeof(T)))
@@ -65,7 +65,7 @@ namespace Parse.Utilities
                     Type innerType = ReflectionHelpers.GetGenericTypeArguments(typeof(T))[0];
                     if (ReflectionHelpers.IsPrimitive(innerType))
                     {
-                        return (T) Convert.ChangeType(value, innerType);
+                        return (T) Convert.ChangeType(value, innerType, System.Globalization.CultureInfo.InvariantCulture);
                     }
                 }
                 Type listType = GetInterfaceType(value.GetType(), typeof(IList<>));


### PR DESCRIPTION
This PR adds invariant culture to the conversion methods used in Parse.
It prevents conversion based on a device's locale (e.g. french or german) to error on numbers encoded with invariant/US locale (which uses . instead of , as decimal delimiter).

In addition a test method is added (to check this method on the developers machine locale)
The test might be extended to explicitly use non-invariant locales for testing (e.g. german or french) to allow it to properly work on machines not using those locales by default. 
I'm not quite sure on what basis I should pick those locales to test again, except for those two I know of which caused the error described in issue #305. (Feedback is appreciated on this one)

This pull request handles issue #305 