### PR TITLE
Fix StorageController.LoadAsync()

### DIFF
--- a/Parse/Internal/Storage/Controller/StorageController.cs
+++ b/Parse/Internal/Storage/Controller/StorageController.cs
@@ -142,9 +142,9 @@ namespace Parse.Common.Internal
         TaskQueue Queue { get; } = new TaskQueue { };
 
         /// <summary>
-        /// Creates a Parse storage controller and attempts to extract a previously created settings storage file from the persistent storage location.
+        /// Creates a Parse storage controller with the default file wrapper.
         /// </summary>
-        public StorageController() => Storage = new StorageDictionary(File = StorageManager.PersistentStorageFileWrapper);
+        public StorageController() => File = StorageManager.PersistentStorageFileWrapper;
 
         /// <summary>
         /// Creates a Parse storage controller with the provided <paramref name="file"/> wrapper.
@@ -156,7 +156,7 @@ namespace Parse.Common.Internal
         /// Loads a settings dictionary from the file wrapped by <see cref="File"/>.
         /// </summary>
         /// <returns>A storage dictionary containing the deserialized content of the storage file targeted by the <see cref="StorageController"/> instance</returns>
-        public Task<IStorageDictionary<string, object>> LoadAsync() => Queue.Enqueue(toAwait => toAwait.ContinueWith(_ => Task.FromResult((IStorageDictionary<string, object>) Storage) ?? (Storage = new StorageDictionary(File)).LoadAsync().OnSuccess(__ => Storage as IStorageDictionary<string, object>)).Unwrap(), CancellationToken.None);
+        public Task<IStorageDictionary<string, object>> LoadAsync() => Queue.Enqueue(toAwait => toAwait.ContinueWith(_ => (Storage != null) ? Task.FromResult((IStorageDictionary<string, object>) Storage) : (Storage = new StorageDictionary(File)).LoadAsync().OnSuccess(__ => Storage as IStorageDictionary<string, object>)).Unwrap(), CancellationToken.None);
 
         /// <summary>
         /// 

--- a/Parse/Internal/Utilities/StorageManager.cs
+++ b/Parse/Internal/Utilities/StorageManager.cs
@@ -41,7 +41,7 @@ namespace Parse.Internal.Utilities
         /// <returns>A task that should contain the little-endian 16-bit character string (UTF-16) extracted from the <paramref name="file"/> if the read completes successfully</returns>
         public static async Task<string> ReadAllTextAsync(this FileInfo file)
         {
-            using (StreamReader reader = file.OpenText())
+            using (var reader = new StreamReader(file.FullName, Encoding.Unicode))
                 return await reader.ReadToEndAsync();
         }
 


### PR DESCRIPTION
Fix `StorageController.Storage` null check on `StorageController.LoadAsync()`. 
Before this commit it null checked a Task with a result of `StorageController.Storage`,
which always returns a non null object, instead of checking `StorageController.Storage` itself.

Fix cache reading from UTF-8 to UTF-16 as 
`FileInfo.OpenText` creates a `FileStream` encoded in UTF-8.

Stop `StorageController` from loading its storage on instantiation as it isn't awaitable,
rendering it useless on first access and requiring to call it externally, essentially calling it twice.