### PR TITLE
added issue templates; added stale bot

### DIFF
--- a/.github/ISSUE_TEMPLATE/---1-report-an-issue.md
+++ b/.github/ISSUE_TEMPLATE/---1-report-an-issue.md
@@ -1,0 +1,47 @@
+---
+name: "\U0001F41B Report an issue"
+about: A feature is not working as expected.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### New Issue Checklist
+<!-- Please check the following boxes [ ] -> [x] before submitting your issue. Click the "Preview" tab for better readability. Thanks for reporting this issue! -->
+
+- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server/blob/master/SECURITY.md).
+- [ ] I am not just asking a [question](https://github.com/parse-community/.github/blob/master/SUPPORT.md).
+- [ ] I have searched through [existing issues](https://github.com/parse-community/Parse-SDK-dotNET/issues?q=is%3Aissue).
+- [ ] I can reproduce the issue with the latest versions of [Parse Server](https://github.com/parse-community/parse-server/releases) and the [Parse .NET SDK](https://github.com/parse-community/Parse-SDK-dotNET/releases). <!-- We don't investigate issues for outdated releases. -->
+
+### Issue Description
+<!-- What is the specific issue? -->
+
+### Steps to reproduce
+<!-- How can someone else reproduce the issue? -->
+
+### Actual Outcome
+<!-- What outcome, for example query result, did you get? -->
+
+### Expected Outcome
+<!-- What outcome, for example query result, did you expect? -->
+
+###  Environment
+<!-- Be specific with versions, don't use "latest" or semver ranges like "~x.y.z" or "^x.y.z". -->
+
+Server
+- Parse Server version: `FILL_THIS_OUT`
+- Operating system: `FILL_THIS_OUT`
+- Local or remote host (AWS, Azure, Google Cloud, Heroku, Digital Ocean, etc): `FILL_THIS_OUT`
+
+Database
+- System (MongoDB or Postgres): `FILL_THIS_OUT`
+- Database version: `FILL_THIS_OUT`
+- Local or remote host (MongoDB Atlas, mLab, AWS, Azure, Google Cloud, etc): `FILL_THIS_OUT`
+
+Client
+- Parse .NET SDK version: `FILL_THIS_OUT`
+
+### Logs
+<!-- Include relevant logs here. Turn on additional logging by configuring VERBOSE=1 in your environment. -->

--- a/.github/ISSUE_TEMPLATE/---2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---2-feature-request.md
@@ -1,0 +1,20 @@
+---
+name: "\U0001F4A1 Request a feature"
+about: Suggest new functionality or an enhancement of existing functionality.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🙋🏽‍♀️ Getting help with code
+    url: https://stackoverflow.com/questions/tagged/parse-platform+parse-dotnet-sdk
+    about: Get help with code-level questions on Stack Overflow.
+  - name: 🙋 Getting general help
+    url: https://community.parseplatform.org/c/client-sdks/net-sdk
+    about: Get help with other questions on our Community Forum.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,32 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 45
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - accepted
+  - pinned
+  - security
+  - good first task
+  - up-for-grabs
+  - enhancement
+  - help wanted
+  - bug
+  - greenkeeper
+  - feature
+  - needs more info
+  - discussion
+  - question
+  - pr-submitted
+  - proposal
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Limit to only `issues` not `pulls`
+only: issues
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
Added issue templates as discussed [here](https://community.parseplatform.org/t/harmonize-github-labels-and-usage/583/11) with @TobiasPott.

This PR also includes a bot that marks issues as stale after 45 days of inactivity and closes them after additional 7 days. The bot does not act on issues with certain labels, see file `style.yml`.

The templates are the new ones we recently introduced in parse server and parse JS SDK. So this PR will also be beneficial when transferring issues between repos to have a consistent report format.

