### PR TITLE
ci: Fix incorrect DLL version on release

### DIFF
--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -15,13 +15,13 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
-      - name: Restore .NET dependencies
-        run: dotnet restore /home/runner/work/Parse-SDK-dotNET/Parse-SDK-dotNET/Parse/Parse.csproj
-      - name: Build .NET project
-        run: dotnet build /home/runner/work/Parse-SDK-dotNET/Parse-SDK-dotNET/Parse/Parse.csproj -c Release
-      - name: List output directory contents
-        run: ls -la /home/runner/work/Parse-SDK-dotNET/Parse-SDK-dotNET/Parse/bin/Release/netstandard2.0
+          dotnet-version: '8'
+      # - name: Restore .NET dependencies
+      #   run: dotnet restore /home/runner/work/Parse-SDK-dotNET/Parse-SDK-dotNET/Parse/Parse.csproj
+      # - name: Build .NET project
+      #   run: dotnet build /home/runner/work/Parse-SDK-dotNET/Parse-SDK-dotNET/Parse/Parse.csproj -c Release
+      # - name: List output directory contents
+      #   run: ls -la /home/runner/work/Parse-SDK-dotNET/Parse-SDK-dotNET/Parse/bin/Release/netstandard2.0
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@droidsolutions-oss/semantic-release-update-file": "1.4.0",
         "@semantic-release/changelog": "6.0.0",
         "@semantic-release/commit-analyzer": "9.0.2",
+        "@semantic-release/exec": "6.0.3",
         "@semantic-release/git": "10.0.1",
         "@semantic-release/release-notes-generator": "10.0.3",
         "semantic-release": "19.0.3"
@@ -364,6 +365,35 @@
       "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
       "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
       "dev": true
+    },
+    "node_modules/@semantic-release/exec": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-6.0.3.tgz",
+      "integrity": "sha512-bxAq8vLOw76aV89vxxICecEa8jfaWwYITw6X74zzlO0mc/Bgieqx9kBRz9z96pHectiTAtsCwsQcUyLYWnp3VQ==",
+      "dev": true,
+      "dependencies": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^5.0.0",
+        "lodash": "^4.17.4",
+        "parse-json": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14.17"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=18.0.0"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/@semantic-release/error": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/@semantic-release/git": {
       "version": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@droidsolutions-oss/semantic-release-update-file": "1.4.0",
     "@semantic-release/changelog": "6.0.0",
     "@semantic-release/commit-analyzer": "9.0.2",
+    "@semantic-release/exec": "6.0.3",
     "@semantic-release/git": "10.0.1",
     "@semantic-release/release-notes-generator": "10.0.3",
     "semantic-release": "19.0.3"

--- a/release.config.js
+++ b/release.config.js
@@ -89,6 +89,13 @@ async function config() {
           }
         ]
       }],
+      ["@semantic-release/exec", {
+        'verifyConditionsCmd': 'ls -la /home/runner/work/Parse-SDK-dotNET/Parse-SDK-dotNET/Parse/bin/Release/netstandard2.0',
+        'prepareCmd': 'ls -la /home/runner/work/Parse-SDK-dotNET/Parse-SDK-dotNET/Parse/bin/Release/netstandard2.0',
+        'publishCmd': 'ls -la /home/runner/work/Parse-SDK-dotNET/Parse-SDK-dotNET/Parse/bin/Release/netstandard2.0',
+        'successCmd': 'ls -la /home/runner/work/Parse-SDK-dotNET/Parse-SDK-dotNET/Parse/bin/Release/netstandard2.0',
+        'failCmd': 'ls -la /home/runner/work/Parse-SDK-dotNET/Parse-SDK-dotNET/Parse/bin/Release/netstandard2.0',
+      }],
       ['@droidsolutions-oss/semantic-release-nuget', {
         projectPath: './Parse/Parse.csproj',
         includeSymbols: true,


### PR DESCRIPTION
The release workflow publishes the correct nuget version, but doesn't update the DLL file version. For example Parse 3.0.0 on nuget downloads the Parse.dll with version code 2.0.0. The DLL file is correct, but it's version is not updated correctly. That means the nuget installs the correct Parse.dll file, just the file itself shows an incorrect version, so we won't unpublish the nuget version 3.0.0.