### PR TITLE
Hotfix Add null check before using .Bind(serviceHub) to prevent crash on using .Include in ParseQueries (anonym access)

### DIFF
--- a/Parse/Platform/Objects/ParseObjectClassController.cs
+++ b/Parse/Platform/Objects/ParseObjectClassController.cs
@@ -112,6 +112,7 @@ namespace Parse.Platform.Objects
             Classes.TryGetValue(className, out ParseObjectClass info);
             Mutex.ExitReadLock();
 
+            serviceHub = serviceHub ?? ParseClient.Instance;
             return info is { } ? info.Instantiate().Bind(serviceHub) : new ParseObject(className, serviceHub);
         }
 


### PR DESCRIPTION
Improved fix for this PR

https://github.com/parse-community/Parse-SDK-dotNET/pull/388