### PR TITLE
fix: `ParseObject` Relations not working

### DIFF
--- a/Parse.Tests/EncoderTests.cs
+++ b/Parse.Tests/EncoderTests.cs
@@ -76,13 +76,6 @@ public class EncoderTests
         Assert.AreEqual(Convert.ToBase64String(new byte[] { 1, 2, 3, 4 }), value["base64"]);
     }
 
-    [TestMethod]
-    public void TestEncodeParseObjectWithNoObjectsEncoder()
-    {
-        ParseObject obj = new ParseObject("Corgi");
-
-        Assert.ThrowsException<ArgumentException>(() => NoObjectsEncoder.Instance.Encode(obj, Client));
-    }
 
     [TestMethod]
     public void TestEncodeParseObjectWithPointerOrLocalIdEncoder()

--- a/Parse.Tests/RelationTests.cs
+++ b/Parse.Tests/RelationTests.cs
@@ -1,13 +1,85 @@
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Parse.Abstractions.Infrastructure.Control;
+using Parse.Abstractions.Infrastructure;
 using Parse.Abstractions.Internal;
+using Parse.Abstractions.Platform.Objects;
 using Parse.Infrastructure;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Parse.Platform.Objects;
+using System.Threading;
+using Parse.Abstractions.Platform.Users;
 
 namespace Parse.Tests;
 
 [TestClass]
 public class RelationTests
 {
+    [ParseClassName("TestObject")]
+    private class TestObject : ParseObject { }
+
+    [ParseClassName("Friend")]
+    private class Friend : ParseObject { }
+
+    private ParseClient Client { get; set; }
+
+    [TestInitialize]
+    public void SetUp()
+    {
+        // Initialize the client and ensure the instance is set
+        Client = new ParseClient(new ServerConnectionData { Test = true });
+        Client.Publicize();
+
+        // Register the test classes
+        Client.RegisterSubclass(typeof(TestObject));
+        Client.RegisterSubclass(typeof(Friend));
+        Client.RegisterSubclass(typeof(ParseUser));
+        Client.RegisterSubclass(typeof(ParseSession));
+        Client.RegisterSubclass(typeof(ParseUser));
+
+        // **--- Mocking Setup ---**
+        var hub = new MutableServiceHub(); // Use MutableServiceHub for mocking
+        var mockUserController = new Mock<IParseUserController>();
+        var mockObjectController = new Mock<IParseObjectController>();
+
+        // **Mock SignUpAsync for ParseUser:**
+        mockUserController
+            .Setup(controller => controller.SignUpAsync(
+                It.IsAny<IObjectState>(),
+                It.IsAny<IDictionary<string, IParseFieldOperation>>(),
+            It.IsAny<IServiceHub>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MutableObjectState { ObjectId = "some0neTol4v4" }); // Predefined ObjectId for User
+
+        // **Mock SaveAsync for ParseObject (Friend objects):**
+        int objectSaveCounter = 1; // Counter for Friend ObjectIds
+        mockObjectController
+            .Setup(controller => controller.SaveAsync(
+                It.IsAny<IObjectState>(),
+                It.IsAny<IDictionary<string, IParseFieldOperation>>(),
+                It.IsAny<string>(),
+                It.IsAny<IServiceHub>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => // Use a lambda to generate different ObjectIds for each Friend
+            {
+                return new MutableObjectState { ObjectId = $"mockFriendObjectId{objectSaveCounter++}" };
+            });
+
+        // **Inject Mocks into ServiceHub:**
+        hub.UserController = mockUserController.Object;
+        hub.ObjectController = mockObjectController.Object;
+        //(Client.Services as ServiceHub)..ReplaceWith(hub); // Replace the Client's ServiceHub with the MutableServiceHub
+
+    }
+    
+    [TestCleanup]
+    public void TearDown() => (Client.Services as ServiceHub).Reset();
+
     [TestMethod]
     public void TestRelationQuery()
     {
@@ -24,4 +96,280 @@ public class RelationTests
 
         Assert.AreEqual("child", encoded["redirectClassNameForKey"]);
     }
+
+    [TestMethod]
+    [Description("Tests AddRelationToUserAsync throws exception when user is null")] // Mock difficulty: 1
+    public async Task AddRelationToUserAsync_ThrowsException_WhenUserIsNull()
+    {
+
+        var relatedObjects = new List<ParseObject>
+            {
+                new ParseObject("Friend", Client.Services) { ["name"] = "Friend1" }
+            };
+
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => UserManagement.AddRelationToUserAsync(null, "friends", relatedObjects));
+
+    }
+    [TestMethod]
+    [Description("Tests AddRelationToUserAsync throws exception when relationfield is null")] // Mock difficulty: 1
+    public async Task AddRelationToUserAsync_ThrowsException_WhenRelationFieldIsNull()
+    {
+        var user = new ParseUser() { Username = "TestUser", Password = "TestPass", Services = Client.Services };
+        await user.SignUpAsync();
+        var relatedObjects = new List<ParseObject>
+            {
+                    new ParseObject("Friend", Client.Services) { ["name"] = "Friend1" }
+            };
+        await Assert.ThrowsExceptionAsync<ArgumentException>(() => UserManagement.AddRelationToUserAsync(user, null, relatedObjects));
+    }
+
+    [TestMethod]
+    [Description("Tests UpdateUserRelationAsync throws exception when user is null")] // Mock difficulty: 1
+    public async Task UpdateUserRelationAsync_ThrowsException_WhenUserIsNull()
+    {
+        var relatedObjectsToAdd = new List<ParseObject>
+            {
+                new ParseObject("Friend", Client.Services) { ["name"] = "Friend1" }
+            };
+        var relatedObjectsToRemove = new List<ParseObject>
+                {
+                    new ParseObject("Friend", Client.Services) { ["name"] = "Friend2" }
+                };
+
+
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => UserManagement.UpdateUserRelationAsync(null, "friends", relatedObjectsToAdd, relatedObjectsToRemove));
+    }
+    [TestMethod]
+    [Description("Tests UpdateUserRelationAsync throws exception when relationfield is null")] // Mock difficulty: 1
+    public async Task UpdateUserRelationAsync_ThrowsException_WhenRelationFieldIsNull()
+    {
+        var user = new ParseUser() { Username = "TestUser", Password = "TestPass", Services = Client.Services };
+        await user.SignUpAsync();
+
+        var relatedObjectsToAdd = new List<ParseObject>
+            {
+                new ParseObject("Friend", Client.Services) { ["name"] = "Friend1" }
+            };
+        var relatedObjectsToRemove = new List<ParseObject>
+                {
+                    new ParseObject("Friend", Client.Services) { ["name"] = "Friend2" }
+                };
+
+
+        await Assert.ThrowsExceptionAsync<ArgumentException>(() => UserManagement.UpdateUserRelationAsync(user, null, relatedObjectsToAdd, relatedObjectsToRemove));
+    }
+    [TestMethod]
+    [Description("Tests DeleteUserRelationAsync throws exception when user is null")] // Mock difficulty: 1
+    public async Task DeleteUserRelationAsync_ThrowsException_WhenUserIsNull()
+    {
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => UserManagement.DeleteUserRelationAsync(null, "friends"));
+    }
+    [TestMethod]
+    [Description("Tests DeleteUserRelationAsync throws exception when relationfield is null")] // Mock difficulty: 1
+    public async Task DeleteUserRelationAsync_ThrowsException_WhenRelationFieldIsNull()
+    {
+        var user = new ParseUser() { Username = "TestUser", Password = "TestPass", Services = Client.Services };
+        await user.SignUpAsync();
+
+        await Assert.ThrowsExceptionAsync<ArgumentException>(() => UserManagement.DeleteUserRelationAsync(user, null));
+    }
+    [TestMethod]
+    [Description("Tests GetUserRelationsAsync throws exception when user is null")] // Mock difficulty: 1
+    public async Task GetUserRelationsAsync_ThrowsException_WhenUserIsNull()
+    {
+        await Assert.ThrowsExceptionAsync<ArgumentNullException>(() => UserManagement.GetUserRelationsAsync(null, "friends"));
+    }
+    [TestMethod]
+    [Description("Tests GetUserRelationsAsync throws exception when relationfield is null")] // Mock difficulty: 1
+    public async Task GetUserRelationsAsync_ThrowsException_WhenRelationFieldIsNull()
+    {
+        var user = new ParseUser() { Username = "TestUser", Password = "TestPass", Services = Client.Services };
+        await user.SignUpAsync();
+
+        await Assert.ThrowsExceptionAsync<ArgumentException>(() => UserManagement.GetUserRelationsAsync(user, null));
+    }
+
+
+
+    [TestMethod]
+    [Description("Tests that AddRelationToUserAsync throws when a related object is unsaved")]
+    public async Task AddRelationToUserAsync_ThrowsException_WhenRelatedObjectIsUnsaved()
+    {
+        // Arrange: Create and sign up a test user.
+        var user = new ParseUser() { Username = "TestUser", Password = "TestPass", Services = Client.Services };
+        await user.SignUpAsync();
+
+        // Create an unsaved Friend object (do NOT call SaveAsync).
+        var unsavedFriend = new ParseObject("Friend", Client.Services) { ["name"] = "UnsavedFriend" };
+        var relatedObjects = new List<ParseObject> { unsavedFriend };
+
+        // Act & Assert: Expect an exception when trying to add an unsaved object.
+        await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+            UserManagement.AddRelationToUserAsync(user, "friends", relatedObjects));
+    }
+
+
+    
 }
+
+public static class UserManagement
+{
+    public static async Task AddRelationToUserAsync(ParseUser user, string relationField, IList<ParseObject> relatedObjects)
+    {
+        if (user == null)
+        {
+            throw new ArgumentNullException(nameof(user), "User must not be null.");
+        }
+
+        if (string.IsNullOrEmpty(relationField))
+        {
+            throw new ArgumentException("Relation field must not be null or empty.", nameof(relationField));
+        }
+
+        if (relatedObjects == null || relatedObjects.Count == 0)
+        {
+            Debug.WriteLine("No objects provided to add to the relation.");
+            return;
+        }
+
+        var relation = user.GetRelation<ParseObject>(relationField);
+
+        foreach (var obj in relatedObjects)
+        {
+            relation.Add(obj);
+        }
+
+        await user.SaveAsync();
+        Debug.WriteLine($"Added {relatedObjects.Count} objects to the '{relationField}' relation for user '{user.Username}'.");
+    }
+    public static async Task UpdateUserRelationAsync(ParseUser user, string relationField, IList<ParseObject> toAdd, IList<ParseObject> toRemove)
+    {
+        if (user == null)
+        {
+            throw new ArgumentNullException(nameof(user), "User must not be null.");
+        }
+
+        if (string.IsNullOrEmpty(relationField))
+        {
+            throw new ArgumentException("Relation field must not be null or empty.", nameof(relationField));
+        }
+
+        var relation = user.GetRelation<ParseObject>(relationField);
+
+        // Add objects to the relation
+        if (toAdd != null && toAdd.Count > 0)
+        {
+            foreach (var obj in toAdd)
+            {
+                relation.Add(obj);
+            }
+            Debug.WriteLine($"Added {toAdd.Count} objects to the '{relationField}' relation.");
+        }
+
+        // Remove objects from the relation
+        if (toRemove != null && toRemove.Count > 0)
+        {
+
+            foreach (var obj in toRemove)
+            {
+                relation.Remove(obj);
+            }
+            Debug.WriteLine($"Removed {toRemove.Count} objects from the '{relationField}' relation.");
+        }
+
+        await user.SaveAsync();
+    }
+    public static async Task DeleteUserRelationAsync(ParseUser user, string relationField)
+    {
+        if (user == null)
+        {
+            throw new ArgumentNullException(nameof(user), "User must not be null.");
+        }
+
+        if (string.IsNullOrEmpty(relationField))
+        {
+            throw new ArgumentException("Relation field must not be null or empty.", nameof(relationField));
+        }
+
+        var relation = user.GetRelation<ParseObject>(relationField);
+        var relatedObjects = await relation.Query.FindAsync();
+
+
+        foreach (var obj in relatedObjects)
+        {
+            relation.Remove(obj);
+        }
+
+        await user.SaveAsync();
+        Debug.WriteLine($"Removed all objects from the '{relationField}' relation for user '{user.Username}'.");
+    }
+    public static async Task ManageUserRelationsAsync(ParseClient client)
+    {
+        // Get the current user
+        var user = await ParseClient.Instance.GetCurrentUser();
+
+        if (user == null)
+        {
+            Debug.WriteLine("No user is currently logged in.");
+            return;
+        }
+
+        const string relationField = "friends"; // Example relation field name
+
+        // Create related objects to add
+        var relatedObjectsToAdd = new List<ParseObject>
+    {
+        new ParseObject("Friend", client.Services) { ["name"] = "Alice" },
+        new ParseObject("Friend", client.Services) { ["name"] = "Bob" }
+    };
+
+        // Save related objects to the server before adding to the relation
+        foreach (var obj in relatedObjectsToAdd)
+        {
+            await obj.SaveAsync();
+        }
+
+        // Add objects to the relation
+        await AddRelationToUserAsync(user, relationField, relatedObjectsToAdd);
+
+        // Query the relation
+        var relatedObjects = await GetUserRelationsAsync(user, relationField);
+
+        // Update the relation (add and remove objects)
+        var relatedObjectsToRemove = new List<ParseObject> { relatedObjects[0] }; // Remove the first related object
+        var newObjectsToAdd = new List<ParseObject>
+    {
+        new ParseObject("Friend", client.Services) { ["name"] = "Charlie" }
+    };
+
+        foreach (var obj in newObjectsToAdd)
+        {
+            await obj.SaveAsync();
+        }
+
+        await UpdateUserRelationAsync(user, relationField, newObjectsToAdd, relatedObjectsToRemove);
+
+        // Delete the relation
+        // await DeleteUserRelationAsync(user, relationField);
+    }
+    public static async Task<IList<ParseObject>> GetUserRelationsAsync(ParseUser user, string relationField)
+    {
+        if (user == null)
+        {
+            throw new ArgumentNullException(nameof(user), "User must not be null.");
+        }
+
+        if (string.IsNullOrEmpty(relationField))
+        {
+            throw new ArgumentException("Relation field must not be null or empty.", nameof(relationField));
+        }
+
+        var relation = user.GetRelation<ParseObject>(relationField);
+
+        var results = await relation.Query.FindAsync();
+        Debug.WriteLine($"Retrieved {results.Count()} objects from the '{relationField}' relation for user '{user.Username}'.");
+        return results.ToList();
+    }
+
+}
+

--- a/Parse.Tests/RelationTests.cs
+++ b/Parse.Tests/RelationTests.cs
@@ -73,7 +73,6 @@ public class RelationTests
         // **Inject Mocks into ServiceHub:**
         hub.UserController = mockUserController.Object;
         hub.ObjectController = mockObjectController.Object;
-        //(Client.Services as ServiceHub)..ReplaceWith(hub); // Replace the Client's ServiceHub with the MutableServiceHub
 
     }
     
@@ -349,8 +348,6 @@ public static class UserManagement
 
         await UpdateUserRelationAsync(user, relationField, newObjectsToAdd, relatedObjectsToRemove);
 
-        // Delete the relation
-        // await DeleteUserRelationAsync(user, relationField);
     }
     public static async Task<IList<ParseObject>> GetUserRelationsAsync(ParseUser user, string relationField)
     {

--- a/Parse/Abstractions/Infrastructure/IJsonConvertible.cs
+++ b/Parse/Abstractions/Infrastructure/IJsonConvertible.cs
@@ -11,5 +11,6 @@ public interface IJsonConvertible
     /// Converts the object to a data structure that can be converted to JSON.
     /// </summary>
     /// <returns>An object to be JSONified.</returns>
-    IDictionary<string, object> ConvertToJSON(IServiceHub serviceHub=default);
+    
+    object ConvertToJSON(IServiceHub serviceHub=default);
 }

--- a/Parse/Infrastructure/Control/ParseAddOperation.cs
+++ b/Parse/Infrastructure/Control/ParseAddOperation.cs
@@ -49,7 +49,7 @@ public class ParseAddOperation : IParseFieldOperation
         return result;
     }
 
-    public IDictionary<string, object> ConvertToJSON(IServiceHub serviceHub = default)
+    public object ConvertToJSON(IServiceHub serviceHub = default)
     {
         // Convert the data into JSON-compatible structures
         var encodedObjects = Data.Select(EncodeForParse).ToList();

--- a/Parse/Infrastructure/Control/ParseAddUniqueOperation.cs
+++ b/Parse/Infrastructure/Control/ParseAddUniqueOperation.cs
@@ -55,7 +55,7 @@ public class ParseAddUniqueOperation : IParseFieldOperation
         return result;
     }
 
-    public IDictionary<string, object> ConvertToJSON(IServiceHub serviceHub = default)
+    public object ConvertToJSON(IServiceHub serviceHub = default)
     {
         // Converts the data into JSON-compatible structures
         var encodedObjects = Data.Select(EncodeForParse).ToList();

--- a/Parse/Infrastructure/Control/ParseDeleteOperation.cs
+++ b/Parse/Infrastructure/Control/ParseDeleteOperation.cs
@@ -18,7 +18,7 @@ public class ParseDeleteOperation : IParseFieldOperation
     private ParseDeleteOperation() { }
 
     // Replaced Encode with ConvertToJSON
-    public IDictionary<string, object> ConvertToJSON(IServiceHub serviceHub = default)
+    public object ConvertToJSON(IServiceHub serviceHub = default)
     {
         return new Dictionary<string, object>
         {

--- a/Parse/Infrastructure/Control/ParseIncrementOperation.cs
+++ b/Parse/Infrastructure/Control/ParseIncrementOperation.cs
@@ -97,7 +97,7 @@ public class ParseIncrementOperation : IParseFieldOperation
     public ParseIncrementOperation(object amount) => Amount = amount;
 
     // Updated Encode to ConvertToJSON
-    public IDictionary<string, object> ConvertToJSON(IServiceHub serviceHub = default)
+    public object ConvertToJSON(IServiceHub serviceHub = default)
     {
         // Updated to produce a JSON-compatible structure
         return new Dictionary<string, object>

--- a/Parse/Infrastructure/Control/ParseRelationOperation.cs
+++ b/Parse/Infrastructure/Control/ParseRelationOperation.cs
@@ -36,33 +36,6 @@ public class ParseRelationOperation : IParseFieldOperation
         Removals = new ReadOnlyCollection<string>(GetIdsFromObjects(removes).ToList());
     }
 
-    public object Encode(IServiceHub serviceHub)
-    {
-        List<object> additions = Additions.Select(id => PointerOrLocalIdEncoder.Instance.Encode(ClassController.CreateObjectWithoutData(TargetClassName, id, serviceHub), serviceHub)).ToList(), removals = Removals.Select(id => PointerOrLocalIdEncoder.Instance.Encode(ClassController.CreateObjectWithoutData(TargetClassName, id, serviceHub), serviceHub)).ToList();
-
-        Dictionary<string, object> addition = additions.Count == 0 ? default : new Dictionary<string, object>
-        {
-            ["__op"] = "AddRelation",
-            ["objects"] = additions
-        };
-
-        Dictionary<string, object> removal = removals.Count == 0 ? default : new Dictionary<string, object>
-        {
-            ["__op"] = "RemoveRelation",
-            ["objects"] = removals
-        };
-
-        if (addition is { } && removal is { })
-        {
-            return new Dictionary<string, object>
-            {
-                ["__op"] = "Batch",
-                ["ops"] = new[] { addition, removal }
-            };
-        }
-        return addition ?? removal;
-    }
-
     public IParseFieldOperation MergeWithPrevious(IParseFieldOperation previous)
     {
         return previous switch
@@ -88,8 +61,8 @@ public class ParseRelationOperation : IParseFieldOperation
     }
 
     public string TargetClassName { get; }
-
-    public object Value => throw new NotImplementedException();
+    
+    public object Value => Additions.ToList();
 
     IEnumerable<string> GetIdsFromObjects(IEnumerable<ParseObject> objects)
     {
@@ -109,5 +82,30 @@ public class ParseRelationOperation : IParseFieldOperation
         return objects.Select(entity => entity.ObjectId).Distinct();
     }
 
-    public IDictionary<string, object> ConvertToJSON(IServiceHub serviceHub = null) => throw new NotImplementedException();
+    public object ConvertToJSON(IServiceHub serviceHub = null)
+    {
+        List<object> additions = Additions.Select(id => PointerOrLocalIdEncoder.Instance.Encode(ClassController.CreateObjectWithoutData(TargetClassName, id, serviceHub), serviceHub)).ToList(), removals = Removals.Select(id => PointerOrLocalIdEncoder.Instance.Encode(ClassController.CreateObjectWithoutData(TargetClassName, id, serviceHub), serviceHub)).ToList();
+
+        Dictionary<string, object> addition = additions.Count == 0 ? default : new Dictionary<string, object>
+        {
+            ["__op"] = "AddRelation",
+            ["objects"] = additions
+        };
+
+        Dictionary<string, object> removal = removals.Count == 0 ? default : new Dictionary<string, object>
+        {
+            ["__op"] = "RemoveRelation",
+            ["objects"] = removals
+        };
+
+        if (addition is { } && removal is { })
+        {
+            return new Dictionary<string, object>
+            {
+                ["__op"] = "Batch",
+                ["ops"] = new[] { addition, removal }
+            };
+        }
+        return addition ?? removal;
+    }
 }

--- a/Parse/Infrastructure/Control/ParseRemoveOperation.cs
+++ b/Parse/Infrastructure/Control/ParseRemoveOperation.cs
@@ -39,7 +39,7 @@ public class ParseRemoveOperation : IParseFieldOperation
             : new List<object> { }; // Return empty list if no previous value
     }
 
-    public IDictionary<string, object> ConvertToJSON(IServiceHub serviceHub = default)
+    public object ConvertToJSON(IServiceHub serviceHub = default)
     {
         // Convert data to a JSON-compatible structure
         var encodedObjects = Data.Select(obj => PointerOrLocalIdEncoder.Instance.Encode(obj, serviceHub)).ToList();

--- a/Parse/Infrastructure/Control/ParseSetOperation.cs
+++ b/Parse/Infrastructure/Control/ParseSetOperation.cs
@@ -14,7 +14,7 @@ public class ParseSetOperation : IParseFieldOperation
     }
 
     // Replace Encode with ConvertToJSON
-    public IDictionary<string, object> ConvertToJSON(IServiceHub serviceHub = default)
+    public object ConvertToJSON(IServiceHub serviceHub = default)
     {
         if (serviceHub == null)
         {
@@ -26,7 +26,7 @@ public class ParseSetOperation : IParseFieldOperation
         // For simple values, return them directly (avoid unnecessary __op)
         if (Value != null && (Value.GetType().IsPrimitive || Value is string))
         {
-            return new Dictionary<string, object> { ["value"] = Value };
+            return Value ;
         }
 
         // If the encoded value is a dictionary, return it directly

--- a/Parse/Infrastructure/Execution/ParseCommandRunner.cs
+++ b/Parse/Infrastructure/Execution/ParseCommandRunner.cs
@@ -75,12 +75,16 @@ public class ParseCommandRunner : IParseCommandRunner
         var responseCode = (int) statusCode;
 
 
-        if (responseCode == 200)
+        if (responseCode == 200) //action successfully done
         {
             
         }
         else if (responseCode == 201)
         {
+        }
+        else if(responseCode == 400) // Bad Request
+        {
+            //throw new ParseFailureException(ParseFailureException.ErrorCode., content);
         }
         else if (responseCode == 404)
         {

--- a/Parse/Infrastructure/Execution/ParseCommandRunner.cs
+++ b/Parse/Infrastructure/Execution/ParseCommandRunner.cs
@@ -73,20 +73,8 @@ public class ParseCommandRunner : IParseCommandRunner
         var statusCode = response.Item1;
          var content = response.Item2;
         var responseCode = (int) statusCode;
-
-
-        if (responseCode == 200) //action successfully done
-        {
-            
-        }
-        else if (responseCode == 201)
-        {
-        }
-        else if(responseCode == 400) // Bad Request
-        {
-            //throw new ParseFailureException(ParseFailureException.ErrorCode., content);
-        }
-        else if (responseCode == 404)
+        
+        if (responseCode == 404)
         {
             throw new ParseFailureException(ParseFailureException.ErrorCode.ERROR404, "Error 404");
         }

--- a/Parse/Infrastructure/Execution/UniversalWebClient.cs
+++ b/Parse/Infrastructure/Execution/UniversalWebClient.cs
@@ -38,6 +38,7 @@ public class UniversalWebClient : IWebClient
     public UniversalWebClient(BCLWebClient client) => Client = client;
 
     BCLWebClient Client { get; set; }
+    /// <inheritdoc/>
     public async Task<Tuple<HttpStatusCode, string>> ExecuteAsync(
     WebRequest httpRequest,
     IProgress<IDataTransferLevel> uploadProgress,
@@ -79,53 +80,48 @@ public class UniversalWebClient : IWebClient
         HttpResponseMessage response = await Client.SendAsync(message, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         uploadProgress.Report(new DataTransferLevel { Amount = 1 });
 
-        Stream responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
-
-
+        long? totalLength = response.Content.Headers.ContentLength;
 
         MemoryStream resultStream = new MemoryStream { };
-        int bufferSize = 4096, bytesRead = 0;
-        byte[] buffer = new byte[bufferSize];
-        long totalLength = -1, readSoFar = 0;
-
         try
         {
-            totalLength = responseStream.Length;
-        }
-        catch
-        {
-            Console.WriteLine("Unsupported length...");
-        };
-
-
-        while ((bytesRead = await responseStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken)) > 0)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            await resultStream.WriteAsync(buffer, 0, bytesRead, cancellationToken);
-            cancellationToken.ThrowIfCancellationRequested();
-            readSoFar += bytesRead;
-
-            if (totalLength > -1)
+            using (var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken))
             {
-                downloadProgress.Report(new DataTransferLevel { Amount = (double) readSoFar / totalLength });
+                byte[] buffer = new byte[4096];
+                int bytesRead;
+                long readSoFar = 0;
+                while ((bytesRead = await responseStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken)) > 0)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    await resultStream.WriteAsync(buffer, 0, bytesRead, cancellationToken);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    readSoFar += bytesRead;
+
+
+                    if (totalLength.HasValue && totalLength > 0)
+                    {
+                        downloadProgress.Report(new DataTransferLevel { Amount = (double) readSoFar / totalLength.Value });
+                    }
+
+
+                }
             }
+
+            if (!totalLength.HasValue || totalLength <= 0)
+            {
+                downloadProgress.Report(new DataTransferLevel { Amount = 1.0 }); // Report completion if total length is unknown
+            }
+
+
+            byte[] resultAsArray = resultStream.ToArray();
+            string resultString = Encoding.UTF8.GetString(resultAsArray, 0, resultAsArray.Length);
+            //think of throwing better error when login fails for non verified 
+            return new Tuple<HttpStatusCode, string>(response.StatusCode, resultString);
         }
-
-        responseStream.Dispose();
-
-        if (totalLength == -1)
+        finally
         {
-            downloadProgress.Report(new DataTransferLevel { Amount = 1.0 });
+            resultStream.Dispose();
         }
-
-        byte[] resultAsArray = resultStream.ToArray();
-        resultStream.Dispose();
-
-        // Assume UTF-8 encoding.
-        string resultString = Encoding.UTF8.GetString(resultAsArray, 0, resultAsArray.Length);
-
-        return new Tuple<HttpStatusCode, string>(response.StatusCode, resultString);
     }
-
 }

--- a/Parse/Platform/Configuration/ParseConfiguration.cs
+++ b/Parse/Platform/Configuration/ParseConfiguration.cs
@@ -106,7 +106,7 @@ public class ParseConfiguration : IJsonConvertible
     /// <returns>The value for the key.</returns>
     virtual public object this[string key] => Properties[key];
 
-    public IDictionary<string, object> ConvertToJSON(IServiceHub serviceHub = default)
+    public object ConvertToJSON(IServiceHub serviceHub = default)
     {
         return new Dictionary<string, object>
         {

--- a/Parse/Platform/Configuration/ParseCurrentConfigurationController.cs
+++ b/Parse/Platform/Configuration/ParseCurrentConfigurationController.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using Parse.Abstractions.Infrastructure.Data;
 using Parse.Abstractions.Infrastructure;
 using Parse.Abstractions.Platform.Configuration;
+using System.Collections.Generic;
 
 namespace Parse.Platform.Configuration;
 
@@ -42,7 +43,9 @@ internal class ParseCurrentConfigurationController : IParseCurrentConfigurationC
         _currentConfiguration = target;
 
         var data = await _storageController.LoadAsync();
-        await data.AddAsync(CurrentConfigurationKey, ParseClient.SerializeJsonString(((IJsonConvertible) target).ConvertToJSON()));
+        var jsonData = ((IJsonConvertible) target).ConvertToJSON() as IDictionary<string,object>;
+
+        await data.AddAsync(CurrentConfigurationKey, ParseClient.SerializeJsonString(jsonData));
     }
 
     public async Task ClearCurrentConfigAsync()

--- a/Parse/Platform/Files/ParseFile.cs
+++ b/Parse/Platform/Files/ParseFile.cs
@@ -165,7 +165,7 @@ public class ParseFile : IJsonConvertible
 
     #endregion
 
-    public IDictionary<string, object> ConvertToJSON(IServiceHub serviceHub = default)
+    public object ConvertToJSON(IServiceHub serviceHub = default)
     {
         if (IsDirty)
         {

--- a/Parse/Platform/Location/ParseGeoPoint.cs
+++ b/Parse/Platform/Location/ParseGeoPoint.cs
@@ -91,7 +91,7 @@ public struct ParseGeoPoint : IJsonConvertible
         return new ParseGeoDistance(2 * Math.Asin(Math.Sqrt(a)));
     }
 
-    public IDictionary<string, object> ConvertToJSON(IServiceHub serviceHub = default)
+    public object ConvertToJSON(IServiceHub serviceHub = default)
     {
         return new Dictionary<string, object> {
         {"__type", "GeoPoint"},

--- a/Parse/Platform/Relations/ParseRelation.cs
+++ b/Parse/Platform/Relations/ParseRelation.cs
@@ -70,7 +70,7 @@ public abstract class ParseRelationBase : IJsonConvertible
         TargetClassName = change.TargetClassName;
     }
 
-    public IDictionary<string, object> ConvertToJSON(IServiceHub serviceHub = default)
+    public object ConvertToJSON(IServiceHub serviceHub = default)
     {
         return new Dictionary<string, object>
         {

--- a/Parse/Platform/Security/ParseACL.cs
+++ b/Parse/Platform/Security/ParseACL.cs
@@ -105,7 +105,7 @@ public class ParseACL : IJsonConvertible
         SetWriteAccess(owner, true);
     }
 
-    public IDictionary<string, object> ConvertToJSON(IServiceHub serviceHub = default)
+    public object ConvertToJSON(IServiceHub serviceHub = default)
     {
         Dictionary<string, object> result = new Dictionary<string, object>();
         foreach (string user in readers.Union(writers))


### PR DESCRIPTION
This PR aims at fixing only Parse Relations and its related operations (Add, Set, etc..)

- Changed the return time of `ConvertToJSON` to return "object" as we now use that one method to pass both primitive and complex datatypes like Dictionnary for Relations.

- Implemented `ConvertToJSON `in ParseRelationOperations which now fixes Relations completely (Before, the related object would save but its pointer was never referenced)
- Removed `Encode()` as `ConvertToJSON` is now the method called.
- Added Unit Tests.

- Closes #404 